### PR TITLE
Add dark theme support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { ArrowUpIcon, ArrowDownIcon } from 'lucide-react';
+import { ThemeProvider } from './components/theme-provider';
+import { ThemeToggle } from './components/theme-toggle';
 
 const App = () => {
-  const [priceData, setPriceData] = useState([
+  const [priceData] = useState([
     { timestamp: '00:00', price: 107.23 },
     { timestamp: '04:00', price: 108.45 },
     { timestamp: '08:00', price: 106.89 },
@@ -14,7 +16,7 @@ const App = () => {
     { timestamp: '24:00', price: 112.45 }
   ]);
 
-  const [news, setNews] = useState([
+  const [news] = useState([
     {
       id: 1,
       title: 'Solana DeFi Ecosystem Sees Major Growth',
@@ -40,66 +42,82 @@ const App = () => {
   const priceChangePercent = +2.12;
 
   return (
-    <div className="min-h-screen bg-gray-100 p-8">
-      <div className="max-w-7xl mx-auto space-y-6">
-        <h1 className="text-4xl font-bold text-gray-900 mb-8">Solana Dashboard</h1>
-        
-        {/* Price Section */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Current Price</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-baseline space-x-2">
-                <span className="text-4xl font-bold">${currentPrice}</span>
-                <span className={`flex items-center ${priceChange >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                  {priceChange >= 0 ? <ArrowUpIcon className="w-4 h-4" /> : <ArrowDownIcon className="w-4 h-4" />}
-                  {Math.abs(priceChange).toFixed(2)} ({Math.abs(priceChangePercent).toFixed(2)}%)
-                </span>
-              </div>
-            </CardContent>
-          </Card>
-          
-          <Card>
-            <CardHeader>
-              <CardTitle>24h Price Chart</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="h-48">
-                <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={priceData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="timestamp" />
-                    <YAxis domain={['auto', 'auto']} />
-                    <Tooltip />
-                    <Line type="monotone" dataKey="price" stroke="#8884d8" strokeWidth={2} />
-                  </LineChart>
-                </ResponsiveContainer>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* News Section */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Latest News</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              {news.map((item) => (
-                <div key={item.id} className="border-b pb-4 last:border-b-0">
-                  <h3 className="font-semibold text-lg">{item.title}</h3>
-                  <p className="text-sm text-gray-500">{item.date}</p>
-                  <p className="mt-2">{item.snippet}</p>
-                </div>
-              ))}
+    <ThemeProvider defaultTheme="system" storageKey="solana-dashboard-theme">
+      <div className="min-h-screen bg-background transition-colors">
+        <ThemeToggle />
+        <div className="p-8">
+          <div className="max-w-7xl mx-auto space-y-6">
+            <h1 className="text-4xl font-bold text-foreground mb-8">Solana Dashboard</h1>
+            
+            {/* Price Section */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Current Price</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-baseline space-x-2">
+                    <span className="text-4xl font-bold">${currentPrice}</span>
+                    <span className={`flex items-center ${priceChange >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                      {priceChange >= 0 ? <ArrowUpIcon className="w-4 h-4" /> : <ArrowDownIcon className="w-4 h-4" />}
+                      {Math.abs(priceChange).toFixed(2)} ({Math.abs(priceChangePercent).toFixed(2)}%)
+                    </span>
+                  </div>
+                </CardContent>
+              </Card>
+              
+              <Card>
+                <CardHeader>
+                  <CardTitle>24h Price Chart</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="h-48">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={priceData}>
+                        <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                        <XAxis dataKey="timestamp" className="text-muted-foreground" />
+                        <YAxis className="text-muted-foreground" />
+                        <Tooltip 
+                          contentStyle={{
+                            backgroundColor: 'var(--background)',
+                            borderColor: 'var(--border)'
+                          }}
+                          labelStyle={{ color: 'var(--foreground)' }}
+                        />
+                        <Line 
+                          type="monotone" 
+                          dataKey="price" 
+                          stroke="var(--primary)" 
+                          strokeWidth={2} 
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                </CardContent>
+              </Card>
             </div>
-          </CardContent>
-        </Card>
+
+            {/* News Section */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Latest News</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-4">
+                  {news.map((item) => (
+                    <div key={item.id} className="border-b border-border pb-4 last:border-b-0">
+                      <h3 className="font-semibold text-lg text-foreground">{item.title}</h3>
+                      <p className="text-sm text-muted-foreground">{item.date}</p>
+                      <p className="mt-2 text-foreground">{item.snippet}</p>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
       </div>
-    </div>
+    </ThemeProvider>
   );
 };
 

--- a/src/components/theme-provider.jsx
+++ b/src/components/theme-provider.jsx
@@ -1,0 +1,55 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const ThemeProviderContext = createContext()
+
+export function ThemeProvider({
+  children,
+  defaultTheme = 'system',
+  storageKey = 'vite-ui-theme',
+  ...props
+}) {
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem(storageKey) || defaultTheme
+  )
+
+  useEffect(() => {
+    const root = window.document.documentElement
+
+    root.classList.remove('light', 'dark')
+
+    if (theme === 'system') {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
+        .matches
+        ? 'dark'
+        : 'light'
+
+      root.classList.add(systemTheme)
+      return
+    }
+
+    root.classList.add(theme)
+  }, [theme])
+
+  const value = {
+    theme,
+    setTheme: (theme) => {
+      localStorage.setItem(storageKey, theme)
+      setTheme(theme)
+    },
+  }
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext)
+
+  if (context === undefined)
+    throw new Error('useTheme must be used within a ThemeProvider')
+
+  return context
+}

--- a/src/components/theme-toggle.jsx
+++ b/src/components/theme-toggle.jsx
@@ -1,0 +1,37 @@
+import { Moon, Sun } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useTheme } from './theme-provider'
+
+export function ThemeToggle() {
+  const { setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon" className="fixed top-4 right-4">
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,76 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+ 
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+ 
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+ 
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+ 
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+ 
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+ 
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+ 
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+ 
+    --radius: 0.5rem;
+  }
+ 
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+ 
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+ 
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+ 
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+ 
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+ 
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+ 
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+ 
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+ 
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
+}
+ 
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}


### PR DESCRIPTION
This PR adds dark theme support to the Solana dashboard with the following features:

- Theme toggle button in the top-right corner
- System theme detection
- Persistent theme preference storage
- Smooth theme transitions
- Dark mode optimized colors for all components
- Updated chart colors for dark mode

To complete the setup, you'll need to:

1. Install additional dependencies:
```bash
npx shadcn-ui@latest add button dropdown-menu
```

2. Make sure your tailwind.config.js includes the theme variables
3. Import index.css in your main.jsx file

The theme toggle allows switching between light, dark, and system preference modes.